### PR TITLE
build: adopt Node 24 and pnpm 10 contract

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,10 @@
-FROM node:18.17.0-alpine as installer
-ARG NPM_TOKEN
+FROM node:24.20.0-alpine as installer
 ENV PNPM_HOME="/pnpm"
 ENV PATH="$PNPM_HOME:$PATH"
-RUN corepack enable
+RUN corepack enable && corepack install --global pnpm@10.34.0
 WORKDIR /app
 COPY package.json pnpm-lock.yaml .npmrc ./
-RUN pnpm install
+RUN --mount=type=secret,id=npm_token,env=NPM_TOKEN pnpm install --frozen-lockfile
 RUN rm .npmrc
 
 FROM installer as builder
@@ -15,7 +14,7 @@ COPY ./src  ./src
 RUN pnpm run build
 RUN pnpm prune --prod
 
-FROM gcr.io/distroless/nodejs18-debian11 as prod-server
+FROM node:24.20.0-alpine as prod-server
 WORKDIR /app
 COPY --from=builder app/package.json .
 COPY --from=builder app/pnpm-lock.yaml .

--- a/Dockerfile.worker
+++ b/Dockerfile.worker
@@ -1,11 +1,10 @@
-FROM node:18.17.0-alpine as installer
-ARG NPM_TOKEN
+FROM node:24.20.0-alpine as installer
 ENV PNPM_HOME="/pnpm"
 ENV PATH="$PNPM_HOME:$PATH"
-RUN corepack enable
+RUN corepack enable && corepack install --global pnpm@10.34.0
 WORKDIR /app
 COPY package.json pnpm-lock.yaml .npmrc ./
-RUN pnpm install
+RUN --mount=type=secret,id=npm_token,env=NPM_TOKEN pnpm install --frozen-lockfile
 RUN rm .npmrc
 
 FROM installer as builder
@@ -15,7 +14,7 @@ COPY ./src  ./src
 RUN pnpm run build
 RUN pnpm prune --prod
 
-FROM gcr.io/distroless/nodejs18-debian11 as prod-server
+FROM node:24.20.0-alpine as prod-server
 WORKDIR /app
 COPY --from=builder app/package.json .
 COPY --from=builder app/pnpm-lock.yaml .

--- a/package.json
+++ b/package.json
@@ -16,8 +16,10 @@
     "registry": "https://ghcr.io"
   },
   "engines": {
-    "pnpm": ">=8.6.10"
+    "node": "24.20.0",
+    "pnpm": "10.34.0"
   },
+  "packageManager": "pnpm@10.34.0",
   "scripts": {
     "start": "pnpm run build && cross-env NODE_ENV=production node dist/index-server.js",
     "start-worker": "pnpm run build && cross-env NODE_ENV=production node dist/index-worker.js",


### PR DESCRIPTION
## Summary
- declare Node 24.20.0 and pnpm 10.34.0 in the package manifest
- pin both Dockerfiles' installer and production runtime images to Node 24.20.0
- use Corepack, frozen installs, and BuildKit registry-token secrets

## Validation
- offline install is blocked by the uncached private `@otedesco/notify@0.0.2` tarball; authenticated online installation is tracked by OPS-177