### PR TITLE
ci: pass private registry credentials explicitly

### DIFF
--- a/.github/workflows/quality-checks.yml
+++ b/.github/workflows/quality-checks.yml
@@ -12,4 +12,7 @@ on:
 jobs:
   lint-and-test:
     uses: otedesco/gh-action-templates/.github/workflows/lint-and-test.yml@main
-    secrets: inherit
+    with:
+      registry-auth-required: true
+    secrets:
+      NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/release-docker.yml
+++ b/.github/workflows/release-docker.yml
@@ -11,8 +11,13 @@ concurrency: ${{ github.workflow }}-${{ github.ref }}
 jobs:
   quality-checks:
     uses: otedesco/gh-action-templates/.github/workflows/lint-and-test.yml@main
-    secrets: inherit
+    with:
+      registry-auth-required: true
+    secrets:
+      NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
   release-docker:
     needs: [quality-checks]
     uses: otedesco/gh-action-templates/.github/workflows/release-docker-image.yml@main
-    secrets: inherit
+    secrets:
+      NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+      GH_TOKEN: ${{ secrets.GH_TOKEN }}

--- a/.github/workflows/release-packages.yml
+++ b/.github/workflows/release-packages.yml
@@ -13,8 +13,13 @@ concurrency: ${{ github.workflow }}-${{ github.ref }}
 jobs:
   quality-checks:
     uses: otedesco/gh-action-templates/.github/workflows/lint-and-test.yml@main
-    secrets: inherit
+    with:
+      registry-auth-required: true
+    secrets:
+      NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
   release-packages:
     needs: [quality-checks]
     uses: otedesco/gh-action-templates/.github/workflows/release-package.yml@main
-    secrets: inherit
+    secrets:
+      NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+      GH_TOKEN: ${{ secrets.GH_TOKEN }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,14 @@
+# syntax=docker/dockerfile:1.7
 FROM node:24.20.0-alpine as installer
 ENV PNPM_HOME="/pnpm"
 ENV PATH="$PNPM_HOME:$PATH"
 RUN corepack enable && corepack install --global pnpm@10.34.0
 WORKDIR /app
 COPY package.json pnpm-lock.yaml .npmrc ./
-RUN --mount=type=secret,id=npm_token,env=NPM_TOKEN pnpm install --frozen-lockfile
-RUN rm .npmrc
-
+RUN --mount=type=secret,id=npm_token,required=true \
+    NPM_TOKEN="$(cat /run/secrets/npm_token)" \
+    pnpm install --frozen-lockfile && \
+    rm .npmrc
 FROM installer as builder
 WORKDIR /app
 COPY .swcrc ./

--- a/Dockerfile.worker
+++ b/Dockerfile.worker
@@ -1,12 +1,14 @@
+# syntax=docker/dockerfile:1.7
 FROM node:24.20.0-alpine as installer
 ENV PNPM_HOME="/pnpm"
 ENV PATH="$PNPM_HOME:$PATH"
 RUN corepack enable && corepack install --global pnpm@10.34.0
 WORKDIR /app
 COPY package.json pnpm-lock.yaml .npmrc ./
-RUN --mount=type=secret,id=npm_token,env=NPM_TOKEN pnpm install --frozen-lockfile
-RUN rm .npmrc
-
+RUN --mount=type=secret,id=npm_token,required=true \
+    NPM_TOKEN="$(cat /run/secrets/npm_token)" \
+    pnpm install --frozen-lockfile && \
+    rm .npmrc
 FROM installer as builder
 WORKDIR /app
 COPY .swcrc ./


### PR DESCRIPTION
## Summary
- replace inherited workflow secrets with explicit NPM_TOKEN/GH_TOKEN mappings
- require registry authentication for quality, package, and Docker workflows
- consume NPM_TOKEN through required BuildKit secrets in both Dockerfiles

## Validation
- server and worker production images built successfully
- both `/health` requests returned HTTP 200 with body `Ok`