### PR TITLE
ci: pin shared workflows by commit (OPS-182)

### DIFF
--- a/.github/workflows/quality-checks.yml
+++ b/.github/workflows/quality-checks.yml
@@ -2,6 +2,9 @@ name: Quality checks
 
 on:
   workflow_call:
+    secrets:
+      NPM_TOKEN:
+        required: false
   pull_request:
     types: [opened, edited, reopened, synchronize]
     branches:
@@ -9,8 +12,13 @@ on:
       - 'develop'
       - 'stage'
 
+permissions:
+  contents: read
+
 jobs:
   lint-and-test:
+    permissions:
+      contents: read
     uses: otedesco/gh-action-templates/.github/workflows/lint-and-test.yml@46eefa62da65e573739f4ac686560cd14bb7849b # central quality workflow release 2026-09-02
     with:
       registry-auth-required: true

--- a/.github/workflows/quality-checks.yml
+++ b/.github/workflows/quality-checks.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   lint-and-test:
-    uses: otedesco/gh-action-templates/.github/workflows/lint-and-test.yml@main
+    uses: otedesco/gh-action-templates/.github/workflows/lint-and-test.yml@46eefa62da65e573739f4ac686560cd14bb7849b # central quality workflow release 2026-09-02
     with:
       registry-auth-required: true
     secrets:

--- a/.github/workflows/quality-checks.yml
+++ b/.github/workflows/quality-checks.yml
@@ -2,9 +2,6 @@ name: Quality checks
 
 on:
   workflow_call:
-    secrets:
-      NPM_TOKEN:
-        required: false
   pull_request:
     types: [opened, edited, reopened, synchronize]
     branches:
@@ -12,13 +9,8 @@ on:
       - 'develop'
       - 'stage'
 
-permissions:
-  contents: read
-
 jobs:
   lint-and-test:
-    permissions:
-      contents: read
     uses: otedesco/gh-action-templates/.github/workflows/lint-and-test.yml@46eefa62da65e573739f4ac686560cd14bb7849b # central quality workflow release 2026-09-02
     with:
       registry-auth-required: true

--- a/.github/workflows/release-docker.yml
+++ b/.github/workflows/release-docker.yml
@@ -8,8 +8,12 @@ on:
 
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 
+permissions: {}
+
 jobs:
   quality-checks:
+    permissions:
+      contents: read
     uses: otedesco/gh-action-templates/.github/workflows/lint-and-test.yml@46eefa62da65e573739f4ac686560cd14bb7849b # central quality workflow release 2026-09-02
     with:
       registry-auth-required: true
@@ -17,7 +21,9 @@ jobs:
       NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
   release-docker:
     needs: [quality-checks]
+    permissions:
+      contents: read
+      packages: write
     uses: otedesco/gh-action-templates/.github/workflows/release-docker-image.yml@46eefa62da65e573739f4ac686560cd14bb7849b # central quality workflow release 2026-09-02
     secrets:
       NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-      GH_TOKEN: ${{ secrets.GH_TOKEN }}

--- a/.github/workflows/release-docker.yml
+++ b/.github/workflows/release-docker.yml
@@ -8,12 +8,8 @@ on:
 
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 
-permissions: {}
-
 jobs:
   quality-checks:
-    permissions:
-      contents: read
     uses: otedesco/gh-action-templates/.github/workflows/lint-and-test.yml@46eefa62da65e573739f4ac686560cd14bb7849b # central quality workflow release 2026-09-02
     with:
       registry-auth-required: true
@@ -21,9 +17,7 @@ jobs:
       NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
   release-docker:
     needs: [quality-checks]
-    permissions:
-      contents: read
-      packages: write
     uses: otedesco/gh-action-templates/.github/workflows/release-docker-image.yml@46eefa62da65e573739f4ac686560cd14bb7849b # central quality workflow release 2026-09-02
     secrets:
       NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+      GH_TOKEN: ${{ secrets.GH_TOKEN }}

--- a/.github/workflows/release-docker.yml
+++ b/.github/workflows/release-docker.yml
@@ -10,14 +10,14 @@ concurrency: ${{ github.workflow }}-${{ github.ref }}
 
 jobs:
   quality-checks:
-    uses: otedesco/gh-action-templates/.github/workflows/lint-and-test.yml@main
+    uses: otedesco/gh-action-templates/.github/workflows/lint-and-test.yml@46eefa62da65e573739f4ac686560cd14bb7849b # central quality workflow release 2026-09-02
     with:
       registry-auth-required: true
     secrets:
       NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
   release-docker:
     needs: [quality-checks]
-    uses: otedesco/gh-action-templates/.github/workflows/release-docker-image.yml@main
+    uses: otedesco/gh-action-templates/.github/workflows/release-docker-image.yml@46eefa62da65e573739f4ac686560cd14bb7849b # central quality workflow release 2026-09-02
     secrets:
       NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
       GH_TOKEN: ${{ secrets.GH_TOKEN }}

--- a/.github/workflows/release-packages.yml
+++ b/.github/workflows/release-packages.yml
@@ -12,14 +12,14 @@ concurrency: ${{ github.workflow }}-${{ github.ref }}
 
 jobs:
   quality-checks:
-    uses: otedesco/gh-action-templates/.github/workflows/lint-and-test.yml@main
+    uses: otedesco/gh-action-templates/.github/workflows/lint-and-test.yml@46eefa62da65e573739f4ac686560cd14bb7849b # central quality workflow release 2026-09-02
     with:
       registry-auth-required: true
     secrets:
       NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
   release-packages:
     needs: [quality-checks]
-    uses: otedesco/gh-action-templates/.github/workflows/release-package.yml@main
+    uses: otedesco/gh-action-templates/.github/workflows/release-package.yml@46eefa62da65e573739f4ac686560cd14bb7849b # central quality workflow release 2026-09-02
     secrets:
       NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
       GH_TOKEN: ${{ secrets.GH_TOKEN }}

--- a/.github/workflows/release-packages.yml
+++ b/.github/workflows/release-packages.yml
@@ -10,12 +10,8 @@ on:
 
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 
-permissions: {}
-
 jobs:
   quality-checks:
-    permissions:
-      contents: read
     uses: otedesco/gh-action-templates/.github/workflows/lint-and-test.yml@46eefa62da65e573739f4ac686560cd14bb7849b # central quality workflow release 2026-09-02
     with:
       registry-auth-required: true
@@ -23,9 +19,7 @@ jobs:
       NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
   release-packages:
     needs: [quality-checks]
-    permissions:
-      contents: write
-      pull-requests: write
     uses: otedesco/gh-action-templates/.github/workflows/release-package.yml@46eefa62da65e573739f4ac686560cd14bb7849b # central quality workflow release 2026-09-02
     secrets:
       NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+      GH_TOKEN: ${{ secrets.GH_TOKEN }}

--- a/.github/workflows/release-packages.yml
+++ b/.github/workflows/release-packages.yml
@@ -10,8 +10,12 @@ on:
 
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 
+permissions: {}
+
 jobs:
   quality-checks:
+    permissions:
+      contents: read
     uses: otedesco/gh-action-templates/.github/workflows/lint-and-test.yml@46eefa62da65e573739f4ac686560cd14bb7849b # central quality workflow release 2026-09-02
     with:
       registry-auth-required: true
@@ -19,7 +23,9 @@ jobs:
       NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
   release-packages:
     needs: [quality-checks]
+    permissions:
+      contents: write
+      pull-requests: write
     uses: otedesco/gh-action-templates/.github/workflows/release-package.yml@46eefa62da65e573739f4ac686560cd14bb7849b # central quality workflow release 2026-09-02
     secrets:
       NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-      GH_TOKEN: ${{ secrets.GH_TOKEN }}


### PR DESCRIPTION
Closed because this PR included OPS-183 changes. A clean OPS-182-only replacement PR is being opened.