### PR TITLE
OPS-183: restrict workflow permissions and secrets

### DIFF
--- a/.github/workflows/quality-checks.yml
+++ b/.github/workflows/quality-checks.yml
@@ -2,6 +2,9 @@ name: Quality checks
 
 on:
   workflow_call:
+    secrets:
+      NPM_TOKEN:
+        required: false
   pull_request:
     types: [opened, edited, reopened, synchronize]
     branches:
@@ -9,9 +12,14 @@ on:
       - 'develop'
       - 'stage'
 
+permissions:
+  contents: read
+
 jobs:
   lint-and-test:
-    uses: otedesco/gh-action-templates/.github/workflows/lint-and-test.yml@b0bd33051b7b5b8ebe0a8f5a1c588ea0d466ed2d # central quality workflow release 2026-09-02
+    permissions:
+      contents: read
+    uses: otedesco/gh-action-templates/.github/workflows/lint-and-test.yml@528e0d92182a23a12f9d6d4dae67c4b0e98fcffb # OPS-183 least-privilege workflows
     with:
       registry-auth-required: true
     secrets:

--- a/.github/workflows/release-docker.yml
+++ b/.github/workflows/release-docker.yml
@@ -8,16 +8,22 @@ on:
 
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 
+permissions: {}
+
 jobs:
   quality-checks:
-    uses: otedesco/gh-action-templates/.github/workflows/lint-and-test.yml@b0bd33051b7b5b8ebe0a8f5a1c588ea0d466ed2d # central quality workflow release 2026-09-02
+    permissions:
+      contents: read
+    uses: otedesco/gh-action-templates/.github/workflows/lint-and-test.yml@528e0d92182a23a12f9d6d4dae67c4b0e98fcffb # OPS-183 least-privilege workflows
     with:
       registry-auth-required: true
     secrets:
       NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
   release-docker:
     needs: [quality-checks]
-    uses: otedesco/gh-action-templates/.github/workflows/release-docker-image.yml@b0bd33051b7b5b8ebe0a8f5a1c588ea0d466ed2d # central quality workflow release 2026-09-02
+    permissions:
+      contents: read
+      packages: write
+    uses: otedesco/gh-action-templates/.github/workflows/release-docker-image.yml@528e0d92182a23a12f9d6d4dae67c4b0e98fcffb # OPS-183 least-privilege workflows
     secrets:
       NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-      GH_TOKEN: ${{ secrets.GH_TOKEN }}

--- a/.github/workflows/release-packages.yml
+++ b/.github/workflows/release-packages.yml
@@ -10,16 +10,22 @@ on:
 
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 
+permissions: {}
+
 jobs:
   quality-checks:
-    uses: otedesco/gh-action-templates/.github/workflows/lint-and-test.yml@b0bd33051b7b5b8ebe0a8f5a1c588ea0d466ed2d # central quality workflow release 2026-09-02
+    permissions:
+      contents: read
+    uses: otedesco/gh-action-templates/.github/workflows/lint-and-test.yml@528e0d92182a23a12f9d6d4dae67c4b0e98fcffb # OPS-183 least-privilege workflows
     with:
       registry-auth-required: true
     secrets:
       NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
   release-packages:
     needs: [quality-checks]
-    uses: otedesco/gh-action-templates/.github/workflows/release-package.yml@b0bd33051b7b5b8ebe0a8f5a1c588ea0d466ed2d # central quality workflow release 2026-09-02
+    permissions:
+      contents: write
+      pull-requests: write
+    uses: otedesco/gh-action-templates/.github/workflows/release-package.yml@528e0d92182a23a12f9d6d4dae67c4b0e98fcffb # OPS-183 least-privilege workflows
     secrets:
       NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-      GH_TOKEN: ${{ secrets.GH_TOKEN }}


### PR DESCRIPTION
## Summary
- declare and map only `NPM_TOKEN` for private dependency installation and publishing
- grant quality jobs read-only access, package release contents/PR write access, and container release package write access
- remove custom `GH_TOKEN` mappings from package and container releases
- pin the least-privilege reusable workflows to central commit `528e0d92182a23a12f9d6d4dae67c4b0e98fcffb`

## Dependency
Merge otedesco/gh-action-templates OPS-183 first.